### PR TITLE
Use every token in the dataset to generate a sample

### DIFF
--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -16,6 +16,6 @@ class BabyShakespeareDataset(Dataset):
         if torch.is_tensor(idx):
             idx = idx.tolist()
         if isinstance(idx, slice):
-            return self.data[idx.start: idx.stop: None if idx.step is None else idx.step]
+            return BabyShakespeareDataset(self.data[idx.start: idx.stop: None if idx.step is None else idx.step], self.block_size)
         else:
             return self.data[idx: idx + self.block_size], self.data[idx + 1: idx + self.block_size + 1]

--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -17,7 +17,4 @@ class BabyShakespeareDataset(Dataset):
     def __getitem__(self, idx):
         if torch.is_tensor(idx):
             idx = idx.tolist()
-        if isinstance(idx, slice):
-            return BabyShakespeareDataset(self.data[idx.start: idx.stop: None if idx.step is None else idx.step], self.block_size, self.device)
-        else:
-            return self.data[idx: idx + self.block_size], self.data[idx + 1: idx + self.block_size + 1]
+        return self.data[idx]

--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -1,15 +1,21 @@
 import torch
 
+from collections.abc import Iterable
 from torch.utils.data import Dataset 
 
 class BabyShakespeareDataset(Dataset):
-    def __init__(self, data):
+    def __init__(self, data, block_size):
         self.data = data
+        self.block_size = block_size
 
     def __len__(self):
-        return len(self.data)
+        # -1 for the last token won't have a next token
+        return len(self.data) - self.block_size - 1
     
     def __getitem__(self, idx):
         if torch.is_tensor(idx):
             idx = idx.tolist()
-        return self.data[idx]
+        if isinstance(idx, slice):
+            return self.data[idx.start: idx.stop: None if idx.step is None else idx.step]
+        else:
+            return self.data[idx: idx + self.block_size], self.data[idx + 1: idx + self.block_size + 1]

--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -4,9 +4,11 @@ from collections.abc import Iterable
 from torch.utils.data import Dataset 
 
 class BabyShakespeareDataset(Dataset):
-    def __init__(self, data, block_size):
+    def __init__(self, data, block_size, device):
+        # self.data = data.to(device)
         self.data = data
         self.block_size = block_size
+        self.device = device
 
     def __len__(self):
         # -1 for the last token won't have a next token
@@ -16,6 +18,6 @@ class BabyShakespeareDataset(Dataset):
         if torch.is_tensor(idx):
             idx = idx.tolist()
         if isinstance(idx, slice):
-            return BabyShakespeareDataset(self.data[idx.start: idx.stop: None if idx.step is None else idx.step], self.block_size)
+            return BabyShakespeareDataset(self.data[idx.start: idx.stop: None if idx.step is None else idx.step], self.block_size, self.device)
         else:
             return self.data[idx: idx + self.block_size], self.data[idx + 1: idx + self.block_size + 1]

--- a/data/dataset_utils.py
+++ b/data/dataset_utils.py
@@ -29,10 +29,10 @@ def char_tokenize_play(play_string, vocab_to_ind):
 
 
 def generate_dataset_from_tokens(play_tokens, block_size):
-    """Generate a sequence of tokens from the play string."""
+    """Generate each context and target pair from the play tokens."""
 
     data = []
-    for i in range(0, len(play_tokens) - block_size - 1, block_size): 
+    for i in range(0, len(play_tokens) - block_size - 1): 
         if i + block_size + 1 < len(play_tokens):
             data.append((play_tokens[i:i + block_size], play_tokens[i + 1: i + block_size + 1]))
         elif i + block_size + 1 >= len(play_tokens): 
@@ -41,7 +41,7 @@ def generate_dataset_from_tokens(play_tokens, block_size):
             else:
                 data.append((play_tokens[i: -1], play_tokens[i + 1:]))
 
-    return data 
+    return data
 
 
 def load_dataset(vocab_to_ind, tokenizer, play_paths, block_size=8):
@@ -59,8 +59,10 @@ def load_dataset(vocab_to_ind, tokenizer, play_paths, block_size=8):
         play_in_string = read_corpus(p)
         print("  Tokenizing...")
         play_tokens = tokenizer_func(play_in_string, vocab_to_ind)
-        print("  Dataset length: ", len(play_tokens))
-        data += play_tokens
+        print("  Generating dataset from tokens...")
+        dataset_from_one_play = generate_dataset_from_tokens(play_tokens, block_size)
+        print("  Dataset length: ", len(dataset_from_one_play))
+        data += dataset_from_one_play
 
     print("Length of data: ", len(data))
     print("Tensorizing data...")

--- a/data/dataset_utils.py
+++ b/data/dataset_utils.py
@@ -9,7 +9,7 @@ def word_tokenize_play(play_string, vocab_to_ind):
 
     play_length = len(play_string)
     i = 0
-    tokens = [vocab_to_ind['<start>']]
+    tokens = []
     while i < play_length:
         token = ''
         c_type = get_char_type(play_string[i])
@@ -19,7 +19,6 @@ def word_tokenize_play(play_string, vocab_to_ind):
         token = play_string[i:j]
         tokens.append(vocab_to_ind[token])
         i = j
-    tokens.append(vocab_to_ind['<stop>'])
 
     return tokens
 
@@ -71,9 +70,9 @@ def load_dataset(vocab_to_ind, tokenizer, play_paths, block_size=8):
     return data
 
 
-def generate_dataset(vocab_to_ind, play_paths, tokenizer, block_size=8):
+def generate_dataset(vocab_to_ind, play_paths, tokenizer, device, block_size=8):
     """Get the training and testing dataset."""
     data = load_dataset(vocab_to_ind, tokenizer, play_paths, block_size)
-    dataset = BabyShakespeareDataset(data, block_size)
+    dataset = BabyShakespeareDataset(data, block_size, device)
     return dataset
 

--- a/data/dataset_utils.py
+++ b/data/dataset_utils.py
@@ -60,10 +60,8 @@ def load_dataset(vocab_to_ind, tokenizer, play_paths, block_size=8):
         play_in_string = read_corpus(p)
         print("  Tokenizing...")
         play_tokens = tokenizer_func(play_in_string, vocab_to_ind)
-        print("  Generating dataset from tokens...")
-        dataset_from_one_play = generate_dataset_from_tokens(play_tokens, block_size)
-        print("  Dataset length: ", len(dataset_from_one_play))
-        data += dataset_from_one_play
+        print("  Dataset length: ", len(play_tokens))
+        data += play_tokens
 
     print("Length of data: ", len(data))
     print("Tensorizing data...")
@@ -76,6 +74,6 @@ def load_dataset(vocab_to_ind, tokenizer, play_paths, block_size=8):
 def generate_dataset(vocab_to_ind, play_paths, tokenizer, block_size=8):
     """Get the training and testing dataset."""
     data = load_dataset(vocab_to_ind, tokenizer, play_paths, block_size)
-    dataset = BabyShakespeareDataset(data)
+    dataset = BabyShakespeareDataset(data, block_size)
     return dataset
 

--- a/hyperparams.py
+++ b/hyperparams.py
@@ -1,6 +1,6 @@
 import torch
 
-block_size = 256
+block_size = 128
 batch_size = 128
 dmodel = 256 
 num_of_decoder_layers = 4

--- a/initialize.py
+++ b/initialize.py
@@ -84,6 +84,7 @@ def initialize_dataset(
         print("  Generating dataset artifact")
         full_dataset = generate_dataset(
             vocab_to_ind,
+            device=device,
             play_paths=play_paths,
             block_size=block_size,
             tokenizer=tokenizer,

--- a/train.py
+++ b/train.py
@@ -20,7 +20,9 @@ def train(model, train_loader, test_loader, criterion, optimizer, epochs, model_
         with tqdm(total=len(train_loader), desc=f'Epoch {epoch + 1}/{epochs}', unit='batch') as pbar:
             model.train()
             for batch in train_loader:
-                inputs, labels = batch[:, 0, :].contiguous(), batch[:, 1, :].contiguous()
+                # inputs, labels = batch[:, 0, :].contiguous(), batch[:, 1, :].contiguous()
+                inputs, labels = batch[0].contiguous(), batch[1].contiguous()
+                # inputs, labels = batch[0], batch[1]
                 inputs, labels = inputs.to(device), labels.to(device)
                 optimizer.zero_grad()  # Zero the gradients
                 logits = model(inputs, inputs)  # Forward pass: (B, T, Emb)
@@ -42,7 +44,8 @@ def train(model, train_loader, test_loader, criterion, optimizer, epochs, model_
         with torch.no_grad():
             model.eval()
             for batch in test_loader:
-                inputs, labels = batch[:, 0, :].contiguous(), batch[:, 1, :].contiguous()
+                # inputs, labels = batch[:, 0, :].contiguous(), batch[:, 1, :].contiguous()
+                inputs, labels = batch[0].contiguous(), batch[1].contiguous()
                 inputs, labels = inputs.to(device), labels.to(device)
                 logits = model(inputs, inputs)  # Forward pass: (B, T, Emb)
                 B, T, C = logits.shape


### PR DESCRIPTION
Instead of forcing the stride to be block size when generating the sample, this PR generates one sample for every token.